### PR TITLE
Refactors the base sharing into its own route.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,7 @@ const requireAuth = require('./middleware/jwt-auth');
 const authRouter = require('./auth/auth-router');
 const usersRouter = require('./users/users-router');
 const journalEntriesRouter = require('./journal-entries/journal-entries-router');
+const shareRouter = require('./share/share-router');
 
 const app = express();
 const morganOption = (NODE_ENV === 'production') ? 'tiny' : 'common';
@@ -20,6 +21,7 @@ app.use(helmet());
 app.use('/api/login', authRouter);
 app.use('/api/users', usersRouter);
 app.use('/api/journal-entries', journalEntriesRouter);
+app.use('/api/share', shareRouter);
 
 app.use(function errorHandler(error, req, res, next) {
     let response;

--- a/src/journal-entries/journal-entries-router.js
+++ b/src/journal-entries/journal-entries-router.js
@@ -69,28 +69,5 @@ journalEntriesRouter
             })
             .catch(next);
     });
-    
-journalEntriesRouter
-    .get('/share/json/:entry_id', (req, res, next) => {
-        const db = req.app.get('db');
-        const requestedEntryId = req.params.entry_id;
-
-        JournalEntriesService.getEntryForPermalink(db, requestedEntryId)
-            .then(entry => {
-                if(entry.length === 0) {
-                    return res.status(400).json({error: 'Entry does not exist or is private'});
-                }
-
-                return res
-                    .status(200)
-                    .json({
-                        user: entry[0].user_name,
-                        title: entry[0].title,
-                        body: entry[0].body,
-                        created: entry[0].created
-                    });
-            })
-            .catch(next);
-    });
 
 module.exports = journalEntriesRouter;

--- a/src/journal-entries/journal-entries-service.js
+++ b/src/journal-entries/journal-entries-service.js
@@ -34,26 +34,6 @@ JournalEntriesService = {
                 entry_id: entryId,
             });
     },
-
-    getEntryForPermalink(db, entryId) {
-        return db
-            .from('entries')
-            .select([
-                'users.user_name',
-                'entries.title',
-                'entries.body',
-                'entries.created'
-            ])
-            .innerJoin(
-                'users',
-                'entries.user_id',
-                'users.id'
-            )
-            .where({
-                entry_id: entryId,
-                privacy: 1
-            });
-    }
 };
 
 module.exports = JournalEntriesService;

--- a/src/share/share-router.js
+++ b/src/share/share-router.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const ShareService = require('./share-service');
+
+const shareRouter = express.Router();
+
+shareRouter
+    .get('/json/:entry_id', (req, res, next) => {
+        const db = req.app.get('db');
+        const requestedEntryId = req.params.entry_id;
+
+        ShareService.getEntryForPermalink(db, requestedEntryId)
+            .then(entry => {
+                if (entry.length === 0) {
+                    return res.status(404).json({ error: 'Entry does not exist or is private' });
+                }
+
+                return res
+                    .status(200)
+                    .json({
+                        user: entry[0].user_name,
+                        title: entry[0].title,
+                        body: entry[0].body,
+                        created: entry[0].created
+                    })
+            })
+            .catch(next);
+    });
+
+module.exports = shareRouter;

--- a/src/share/share-service.js
+++ b/src/share/share-service.js
@@ -1,0 +1,23 @@
+ShareService = {
+    getEntryForPermalink(db, entryId) {
+        return db
+            .from('entries')
+            .select([
+                'users.user_name',
+                'entries.title',
+                'entries.body',
+                'entries.created'
+            ])
+            .innerJoin(
+                'users',
+                'entries.user_id',
+                'users.id'
+            )
+            .where({
+                entry_id: entryId,
+                privacy: 1
+            });
+    },
+};
+
+module.exports = ShareService;

--- a/test/journal-entries-routes.spec.js
+++ b/test/journal-entries-routes.spec.js
@@ -194,47 +194,5 @@ describe(`Users routes`, () => {
             });
 
         });
-
-        describe(`/api/journal-entries/share/json/:entry_id`, () => {
-            const validPublicEntryId = testHelpers.createEntriesArray()[2];
-            const validPrivateEntryId = testHelpers.createEntriesArray()[0];
-            const invalidEntryId = '11111111-2222-3333-4444-555555555555'
-
-            it(`responds 400 'Entry does not exist or is private' when an invalid entry_id is given`, () => {
-                return supertest(app)
-                    .get(`/api/journal-entries/share/json/${invalidEntryId}`)
-                    .expect(400, {error: 'Entry does not exist or is private'});
-            });
-
-            it(`responds 400 'Entry does not exist or is private' when a valid entry_id is given but the entry is private`, () => {
-                return supertest(app)
-                    .get(`/api/journal-entries/share/json/${validPrivateEntryId.entry_id}`)
-                    .expect(400, {error: 'Entry does not exist or is private'});
-            });
-
-            it(`responds 200 with the requested entry in a JSON formatted body when a public and valid entry_id is requested`, () => {
-                return supertest(app)
-                .get(`/api/journal-entries/share/json/${validPublicEntryId.entry_id}`)
-                .expect(200)
-                .expect(res => {
-                    // const resultProperties = ['user', 'title', 'body', 'created'];
-                    const resultProperties = ['user', 'title', 'body'];
-                    const expectedUserName = testHelpers.createUsersArray().filter(user =>
-                        user.id === validPublicEntryId.user_id
-                    );
-                    const expectedValues = [
-                        expectedUserName[0].user_name,
-                        validPublicEntryId.title,
-                        validPublicEntryId.body,
-                        // validPublicEntryId.created
-                    ];
-
-                    resultProperties.forEach((prop, index) => {
-                        expect(res.body).to.have.property(prop);
-                        expect(res.body[prop]).to.equal(expectedValues[index]);
-                    });
-                });
-            });
-        });
     });
 });

--- a/test/share-routes.spec.js
+++ b/test/share-routes.spec.js
@@ -1,0 +1,63 @@
+const app = require('../src/app');
+const knex = require('knex');
+
+const testHelpers = require('./test-helpers');
+const { DB_URL } = require('../src/config');
+
+describe(`Users routes`, () => {
+    before(`create db connection`, () => {
+        db = knex({
+            client: 'pg',
+            connection: DB_URL
+        });
+        app.set('db', db);
+    });
+
+    before(`cleanup tables`, () => testHelpers.truncateTables(db));
+    after(`destroy db connection`, () => db.destroy());
+
+    describe(`/api/share/json/:entry_id`, () => {
+        beforeEach(`seed tables`, () => testHelpers.seedAllTables(db));
+        afterEach(`truncate tables`, () => testHelpers.truncateTables(db));
+
+        const validPublicEntryId = testHelpers.createEntriesArray()[2];
+        const validPrivateEntryId = testHelpers.createEntriesArray()[0];
+        const invalidEntryId = '11111111-2222-3333-4444-555555555555'
+
+        it(`responds 404 'Entry does not exist or is private' when an invalid entry_id is given`, () => {
+            return supertest(app)
+                .get(`/api/share/json/${invalidEntryId}`)
+                .expect(404, { error: 'Entry does not exist or is private' });
+        });
+
+        it(`responds 404 'Entry does not exist or is private' when a valid entry_id is given but the entry is private`, () => {
+            return supertest(app)
+                .get(`/api/share/json/${validPrivateEntryId.entry_id}`)
+                .expect(404, { error: 'Entry does not exist or is private' });
+        });
+
+        it(`responds 200 with the requested entry in a JSON formatted body when a public and valid entry_id is requested`, () => {
+            return supertest(app)
+                .get(`/api/share/json/${validPublicEntryId.entry_id}`)
+                .expect(200)
+                .expect(res => {
+                    // const resultProperties = ['user', 'title', 'body', 'created'];
+                    const resultProperties = ['user', 'title', 'body'];
+                    const expectedUserName = testHelpers.createUsersArray().filter(user =>
+                        user.id === validPublicEntryId.user_id
+                    );
+                    const expectedValues = [
+                        expectedUserName[0].user_name,
+                        validPublicEntryId.title,
+                        validPublicEntryId.body,
+                        // validPublicEntryId.created
+                    ];
+
+                    resultProperties.forEach((prop, index) => {
+                        expect(res.body).to.have.property(prop);
+                        expect(res.body[prop]).to.equal(expectedValues[index]);
+                    });
+                });
+        });
+    });
+});


### PR DESCRIPTION
The sharing route was originally nestled under /api/journal-entries/share/*/:entry_id but it made more sense to draw it into its own route /api/share/*/:entry_id as the sharing feature will be expanded upon.